### PR TITLE
feat: add automatic letsencrypt support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends openresty=* openresty-opm=* && \
     luarocks install lua-resty-auto-ssl && \
     ln -sf /usr/local/openresty/nginx/conf /etc/nginx && \
-    mkdir -p /etc/resty-auto-ssl /etc/nginx/stream-sites-enabled /etc/nginx/sites-enabled /var/log/nginx && \
+    mkdir -p /etc/resty-auto-ssl /etc/nginx/ssl /etc/nginx/stream-sites-enabled /etc/nginx/sites-enabled /var/log/nginx && \
     chown www-data /etc/resty-auto-ssl/ && \
     chown root:adm /var/log/nginx && \
     apt-get purge -y gcc make && \

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ An docker label to group server blocks by.
 
 The default prefix to use when looking up labels. All examples below assume the default label prefix.
 
+#### `NGINX_LETSENCRYPT_EMAIL`
+
+> default: `` (none)
+
+The email to use for enabling letsencrypt (required).
+
+#### `NGINX_LETSENCRYPT_CA`
+
+> default: `https://acme-v02.api.letsencrypt.org/directory`
+
+The certificate authority to use
+
 #### `NGINX_PROCESS_LABEL`
 
 > default: `com.dokku.process-type`
@@ -87,6 +99,10 @@ Port treated as https when parsing port mappings.
 #### `nginx.initial-network`
 
 The network name to use when proxying requests to the app container.
+
+#### `nginx.letsencrypt`
+
+When set to `true`, this enables dynamic SSL certificate provisioning via Let's Encrypt for any `https:443` port mappings. Note that the corresponding `http:80` port mapping must exist in order for this to succeed.
 
 #### `nginx.port-mapping`
 

--- a/config.toml
+++ b/config.toml
@@ -18,3 +18,10 @@ dest = "/etc/nginx/ssl.json"
 watch = true
 wait = "500ms:2s"
 notifycmd = "cat /etc/nginx/ssl.json"
+
+[[config]]
+template = "/app/templates/dehydrated.sh.tmpl"
+dest = "/etc/resty-auto-ssl/letsencrypt/conf.d/custom.sh"
+watch = true
+wait = "500ms:2s"
+notifycmd = "/etc/init.d/openresty reload"

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -25,8 +25,41 @@ http {
 
 	gzip on;
 
+	lua_shared_dict auto_ssl 2m;
+	lua_shared_dict auto_ssl_settings 64k;
+	resolver 8.8.8.8;
+
+	init_by_lua_block {
+		auto_ssl = (require "resty.auto-ssl").new()
+
+		-- Define a function to determine which SNI domains to automatically handle
+		-- and register new certificates for. Defaults to not allowing any domains,
+		-- so this must be configured.
+		auto_ssl:set("allow_domain", function(domain)
+			return true
+		end)
+
+		auto_ssl:init()
+	}
+
+	init_worker_by_lua_block {
+		auto_ssl:init_worker()
+	}
+
 	include /usr/local/openresty/nginx/conf/conf.d/*.conf;
 	include /usr/local/openresty/nginx/conf/sites-enabled/*;
+
+	server {
+		listen 127.0.0.1:8999;
+		client_body_buffer_size 128k;
+		client_max_body_size 128k;
+
+		location / {
+			content_by_lua_block {
+				auto_ssl:hook_server()
+			}
+		}
+	}
 }
 
 stream {

--- a/fixtures/grpc.tmpl
+++ b/fixtures/grpc.tmpl
@@ -1,0 +1,13 @@
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS:5000; # app=python process_type=web container_port=5000 network=bridge scheme=grpc
+}
+server {
+    listen                      [::]:80 http2;
+    listen                      80 http2;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    location    / {
+        grpc_pass  grpc://python-web-5000;
+    }
+}

--- a/fixtures/grpcs.cert.tmpl
+++ b/fixtures/grpcs.cert.tmpl
@@ -1,0 +1,17 @@
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS:5000; # app=python process_type=web container_port=5000 network=bridge scheme=grpcs
+}
+server {
+    listen                      [::]:443 ssl http2;
+    listen                      443 ssl http2;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    ssl_certificate             /etc/nginx/ssl/python-server.crt;
+    ssl_certificate_key         /etc/nginx/ssl/python-server.key;
+    ssl_protocols               TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers   off;
+    location    / {
+        grpc_pass  grpc://python-web-5000;
+    }
+}

--- a/fixtures/grpcs.letsencrypt.tmpl
+++ b/fixtures/grpcs.letsencrypt.tmpl
@@ -1,0 +1,21 @@
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS:5000; # app=python process_type=web container_port=5000 network=bridge scheme=grpcs
+}
+server {
+    listen                      [::]:443 ssl http2;
+    listen                      443 ssl http2;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    ssl_certificate_by_lua_block {
+        auto_ssl:ssl_certificate()
+    }
+    # fallback certificates
+    ssl_certificate             /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key         /etc/ssl/resty-auto-ssl-fallback.key;
+    ssl_protocols               TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers   off;
+    location    / {
+        grpc_pass  grpc://python-web-5000;
+    }
+}

--- a/fixtures/http.tmpl
+++ b/fixtures/http.tmpl
@@ -1,0 +1,47 @@
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS:5000; # app=python process_type=web container_port=5000 network=bridge scheme=http
+}
+server {
+    listen                      [::]:80;
+    listen                      80;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    location / {
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-web-5000;
+        proxy_read_timeout      60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+    }
+    error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+    location /400-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 404 /404-error.html;
+    location /404-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+    location /500-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+}

--- a/fixtures/https.cert.tmpl
+++ b/fixtures/https.cert.tmpl
@@ -1,0 +1,63 @@
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS:5000; # app=python process_type=web container_port=5000 network=bridge scheme=http
+}
+server {
+    listen                      [::]:80;
+    listen                      80;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    location / {
+        return 301 https://$host:443$request_uri;
+    }
+}
+server {
+    listen                      [::]:443 ssl http2;
+    listen                      443 ssl http2;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    ssl_certificate             /etc/nginx/ssl/python-server.crt;
+    ssl_certificate_key         /etc/nginx/ssl/python-server.key;
+    ssl_protocols               TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers   off;
+    keepalive_timeout           70;
+    location / {
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-web-5000;
+        proxy_read_timeout      60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+        http2_push_preload      on;
+    }
+    error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+    location /400-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 404 /404-error.html;
+    location /404-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+    location /500-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+}

--- a/fixtures/https.letsencrypt.tmpl
+++ b/fixtures/https.letsencrypt.tmpl
@@ -1,0 +1,72 @@
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS:5000; # app=python process_type=web container_port=5000 network=bridge scheme=http
+}
+server {
+    listen                      [::]:80;
+    listen                      80;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    location ^~ /.well-known/acme-challenge/ {
+        content_by_lua_block {
+            auto_ssl:challenge_server()
+        }
+    }
+    location / {
+        return 301 https://$host:443$request_uri;
+    }
+}
+server {
+    listen                      [::]:443 ssl http2;
+    listen                      443 ssl http2;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    ssl_certificate_by_lua_block {
+        auto_ssl:ssl_certificate()
+    }
+    # fallback certificates
+    ssl_certificate             /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key         /etc/ssl/resty-auto-ssl-fallback.key;
+    ssl_protocols               TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers   off;
+    keepalive_timeout           70;
+    location / {
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-web-5000;
+        proxy_read_timeout      60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+        http2_push_preload      on;
+    }
+    error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+    location /400-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 404 /404-error.html;
+    location /404-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+    location /500-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+}

--- a/templates/dehydrated.sh.tmpl
+++ b/templates/dehydrated.sh.tmpl
@@ -1,0 +1,2 @@
+CONTACT_EMAIL={{ default "" (env "NGINX_LETSENCRYPT_EMAIL") }}
+CA={{ default "https://acme-v02.api.letsencrypt.org/directory" (env "NGINX_LETSENCRYPT_CA") }}

--- a/templates/http.conf.tmpl
+++ b/templates/http.conf.tmpl
@@ -14,7 +14,7 @@
 {{ $port_mappings := split (trim (when (contains $first_container.Labels (printf "%sport-mapping" $label_prefix)) (index $first_container.Labels (printf "%sport-mapping" $label_prefix)) "http:80:5000")) " " }}
 {{ range $_, $port_map := $port_mappings  }}
 {{ $scheme := index (split $port_map ":") 0 }}
-{{ if or (eq $scheme "http") (eq $scheme "https") }}
+{{ if or (eq $scheme "http") (eq $scheme "https") (eq $scheme "grpc") (eq $scheme "grpcs") }}
 {{ $container_port := index (split $port_map ":") 2 }}
 
 {{ $upstream_name := printf "%s-%s-%s" $app $process_type $container_port }}
@@ -54,29 +54,39 @@ upstream {{ $app }}-{{ $process_type }}-{{ $container_port }} {
 {{ $nginx_error_log_path := when (contains $first_container.Labels (printf "%serror-log-path" $label_prefix)) (index $first_container.Labels (printf "%serror-log-path" $label_prefix)) (printf "/var/log/nginx/%s-error.log" $app) }}
 {{ $nginx_domains := when (contains $first_container.Labels (printf "%sdomains" $label_prefix)) (index $first_container.Labels (printf "%sdomains" $label_prefix)) $app }}
 {{ $nginx_https_port := when (contains $first_container.Labels (printf "%shttps-port" $label_prefix)) (index $first_container.Labels (printf "%shttps-port" $label_prefix)) "443" }}
+{{ $nginx_letsencrypt := when (contains $first_container.Labels (printf "%sletsencrypt" $label_prefix)) (index $first_container.Labels (printf "%sletsencrypt" $label_prefix)) "" }}
+{{ $nginx_letsencrypt_enabled := eq $nginx_letsencrypt "true" }}
+{{ $nginx_has_cert := exists (printf "/etc/nginx/ssl/%s-server.key" $app) }}
+{{ $nginx_ssl_enabled := or ($nginx_has_cert) ($nginx_letsencrypt_enabled) }}
 
 {{ $port_mappings := split (trim (when (contains $first_container.Labels (printf "%sport-mapping" $label_prefix)) (index $first_container.Labels (printf "%sport-mapping" $label_prefix)) "http:80:5000")) " " }}
 {{ range $_, $port_map := $port_mappings  }}
 {{ $scheme := index (split $port_map ":") 0 }}
 {{ $host_port := index (split $port_map ":") 1 }}
 {{ $container_port := index (split $port_map ":") 2 }}
-{{ $has_cert := exists (printf "/etc/nginx/ssl/%s-server.key" $app) }}
-{{ if or (and (eq $scheme "https") ($has_cert)) (eq $scheme "http") }}
+{{ if or (and (eq $scheme "https") $nginx_ssl_enabled) (eq $scheme "http") }}
 server {
-    listen                      [{{ $nginx_bind_address_ipv6 }}]:{{ $host_port }}{{ if and (eq $scheme "https") $has_cert }} ssl http2{{ end }};
-    listen                      {{ if $nginx_bind_address_ipv4 }}{{ $nginx_bind_address_ipv4 }}:{{ end }}{{ $host_port }}{{ if and (eq $scheme "https") $has_cert }} ssl http2{{ end }};
+    listen                      [{{ $nginx_bind_address_ipv6 }}]:{{ $host_port }}{{ if and (eq $scheme "https") $nginx_ssl_enabled }} ssl http2{{ end }};
+    listen                      {{ if $nginx_bind_address_ipv4 }}{{ $nginx_bind_address_ipv4 }}:{{ end }}{{ $host_port }}{{ if and (eq $scheme "https") $nginx_ssl_enabled }} ssl http2{{ end }};
     {{ if $nginx_domains }}server_name                 {{ $nginx_domains }};{{ end }}
     access_log                  {{ $nginx_access_log_path }}{{ if and ($nginx_access_log_format) (ne $nginx_access_log_path "off") }} {{ $nginx_access_log_format }}{{ end }};
     error_log                   {{ $nginx_error_log_path }};
 
-    {{ if and (eq $scheme "https") ($has_cert) }}
+    {{ if and (eq $scheme "https") $nginx_ssl_enabled }}
+    {{ if $nginx_has_cert }}
     ssl_certificate             /etc/nginx/ssl/{{ $app }}-server.crt;
     ssl_certificate_key         /etc/nginx/ssl/{{ $app }}-server.key;
+    {{ else if $nginx_letsencrypt_enabled }}
+    ssl_certificate_by_lua_block {
+        auto_ssl:ssl_certificate()
+    }
+
+    # fallback certificates
+    ssl_certificate             /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key         /etc/ssl/resty-auto-ssl-fallback.key;
+    {{ end }}
     ssl_protocols               TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers   off;
-    {{ end }}
-
-    {{ if and (eq $scheme "https") ($has_cert) }}
     keepalive_timeout           70;
     {{ end }}
 
@@ -89,15 +99,13 @@ server {
 
     {{ if $nginx_client_max_body_size }}client_max_body_size {{ $nginx_client_max_body_size }};{{ end }}
 
-    # Do not HTTPS redirect Let's Encrypt ACME challenge
+    {{ if and (eq $host_port "80") (has (printf "https:%s:%s" $nginx_https_port $container_port) $port_mappings) ($nginx_letsencrypt_enabled) }}
     location ^~ /.well-known/acme-challenge/ {
-        auth_basic off;
-        auth_request off;
-        allow all;
-        root /etc/nginx/acme-challenge/{{ $app }};
-        try_files $uri =404;
-        break;
+        content_by_lua_block {
+            auto_ssl:challenge_server()
+        }
     }
+    {{ end }}
 
     {{ if or (eq $scheme "grpc") (eq $scheme "grpcs")}}
 
@@ -105,7 +113,7 @@ server {
         grpc_pass  grpc://{{ $app }}-{{ $container_port }};
     }
 
-    {{ else if and (eq $host_port "80") (has (printf "https:%s:%s" $nginx_https_port $container_port) $port_mappings) ($has_cert) }}
+    {{ else if and (eq $host_port "80") (has (printf "https:%s:%s" $nginx_https_port $container_port) $port_mappings) $nginx_ssl_enabled }}
 
     location / {
         return 301 https://$host:{{ $nginx_https_port }}$request_uri;
@@ -134,8 +142,7 @@ server {
         proxy_set_header        X-Forwarded-Proto {{ $nginx_x_forwarded_proto_value }};
         proxy_set_header        X-Request-Start $msec;
         {{ if $nginx_x_forwarded_ssl }}proxy_set_header       X-Forwarded-Ssl {{ $nginx_x_forwarded_ssl }};{{ end }}
-        {{ if and (eq $scheme "https") ($has_cert) }}http2_push_preload      on; {{ end }}
-
+        {{ if and (eq $scheme "https") $nginx_ssl_enabled }}http2_push_preload      on;{{ end }}
     }
 
     error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
@@ -158,17 +165,26 @@ server {
 
     {{ end }}
 }
-{{ else if or (and (eq $scheme "grpcs") ($has_cert)) (eq $scheme "grpc") }}
+{{ else if or (and (eq $scheme "grpcs") $nginx_ssl_enabled) (eq $scheme "grpc") }}
 server {
-    listen      [{{ $nginx_bind_address_ipv6 }}]:{{ $host_port }}{{ if eq $scheme "grpcs" }}ssl {{ end }} http2;
-    listen      {{ if $nginx_bind_address_ipv4 }}{{ $nginx_bind_address_ipv4 }}:{{ end }}{{ $host_port }}{{ if eq $scheme "grpcs" }}ssl {{ end }} http2;
+    listen                      [{{ $nginx_bind_address_ipv6 }}]:{{ $host_port }}{{ if eq $scheme "grpcs" }} ssl{{ end }} http2;
+    listen                      {{ if $nginx_bind_address_ipv4 }}{{ $nginx_bind_address_ipv4 }}:{{ end }}{{ $host_port }}{{ if eq $scheme "grpcs" }} ssl{{ end }} http2;
     {{ if $nginx_domains }}server_name                 {{ $nginx_domains }};{{ end }}
     access_log                  {{ $nginx_access_log_path }}{{ if and ($nginx_access_log_format) (ne $nginx_access_log_path "off") }} {{ $nginx_access_log_format }}{{ end }};
     error_log                   {{ $nginx_error_log_path }};
 
-    {{ if and (eq $scheme "grpcs") ($has_cert) }}
+    {{ if and (eq $scheme "grpcs") $nginx_ssl_enabled }}
+    {{ if $nginx_has_cert }}
     ssl_certificate             /etc/nginx/ssl/{{ $app }}-server.crt;
     ssl_certificate_key         /etc/nginx/ssl/{{ $app }}-server.key;
+    {{ else if $nginx_letsencrypt_enabled }}
+    ssl_certificate_by_lua_block {
+        auto_ssl:ssl_certificate()
+    }
+    # fallback certificates
+    ssl_certificate             /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key         /etc/ssl/resty-auto-ssl-fallback.key;
+    {{ end }}
     ssl_protocols               TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers   off;
     {{ end }}

--- a/test.bats
+++ b/test.bats
@@ -1,8 +1,9 @@
 #!/usr/bin/env bats
 
 export SYSTEM_NAME="$(uname -s | tr '[:upper:]' '[:lower:]')"
+export TEST_CONTAINER_NAME="nginx-docker-proxy-$(shuf -i 2000-65000 -n 1)"
 
-setup_file() {
+setup() {
   docker container rm -f "nginx-docker-proxy" || true
   docker image rm -f "nginx-docker-proxy:latest" || true
   if [[ -f "/tmp/cid-file" ]]; then
@@ -11,7 +12,7 @@ setup_file() {
   fi
 }
 
-teardown_file() {
+teardown() {
   docker container rm -f "nginx-docker-proxy" || true
   docker image rm -f "nginx-docker-proxy:latest" || true
   if [[ -f "/tmp/cid-file" ]]; then
@@ -56,7 +57,7 @@ teardown_file() {
   assert_success
 }
 
-@test "[start] config generation" {
+@test "[start] grpc" {
   run docker image build -t nginx-docker-proxy:latest .
   echo "output: $output"
   echo "status: $status"
@@ -67,28 +68,252 @@ teardown_file() {
   echo "status: $status"
   assert_success
 
-  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=nginx.domains=derp.com --label=nginx.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web -d dokku/python-sample /start web
+  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=nginx.domains=python.example.com --label=nginx.port-mapping=grpc:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
   echo "output: $output"
   echo "status: $status"
   assert_success
 
   sleep 1
 
+  run docker logs nginx-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  run echo "$IP_ADDRESS"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
   run docker exec -it nginx-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_contains "upstream python-web-5000"
-  assert_output_contains "proxy_pass              http://python-web-5000;"
-  assert_output_contains "server_name                 derp.com;"
-  assert_output_contains "app=python process_type=web container_port=5000 network=bridge scheme=http"
+  assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/grpc.tmpl)"
+}
+
+@test "[start] grpcs cert" {
+  run docker image build -t nginx-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name nginx-docker-proxy nginx-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 2
+
+  run docker logs nginx-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container exec nginx-docker-proxy cp /etc/ssl/resty-auto-ssl-fallback.key /etc/nginx/ssl/python-server.key
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container exec nginx-docker-proxy cp /etc/ssl/resty-auto-ssl-fallback.crt /etc/nginx/ssl/python-server.crt
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm --cidfile /tmp/cid-file --platform linux/amd64 --label=nginx.domains=python.example.com '--label=nginx.port-mapping=grpcs:443:5000' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 1
+
+  run docker logs nginx-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  run echo "$IP_ADDRESS"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker exec -it nginx-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/grpcs.cert.tmpl)"
+}
+
+@test "[start] grpcs letsencrypt" {
+  run docker image build -t nginx-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name nginx-docker-proxy nginx-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=nginx.domains=python.example.com '--label=nginx.port-mapping=grpcs:443:5000' --label=nginx.letsencrypt=true --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 1
+
+  run docker logs nginx-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  run echo "$IP_ADDRESS"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker exec -it nginx-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/grpcs.letsencrypt.tmpl)"
+}
+
+@test "[start] http" {
+  run docker image build -t nginx-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name nginx-docker-proxy nginx-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm -d --cidfile /tmp/cid-file --platform linux/amd64 --label=nginx.domains=python.example.com --label=nginx.port-mapping=http:80:5000 --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 1
+
+  run docker logs nginx-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  run echo "$IP_ADDRESS"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker exec -it nginx-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/http.tmpl)"
+}
+
+@test "[start] https cert" {
+  run docker image build -t nginx-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name nginx-docker-proxy nginx-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 2
+
+  run docker logs nginx-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container exec nginx-docker-proxy cp /etc/ssl/resty-auto-ssl-fallback.key /etc/nginx/ssl/python-server.key
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container exec nginx-docker-proxy cp /etc/ssl/resty-auto-ssl-fallback.crt /etc/nginx/ssl/python-server.crt
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm --cidfile /tmp/cid-file --platform linux/amd64 --label=nginx.domains=python.example.com '--label=nginx.port-mapping=http:80:5000 https:443:5000' --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 1
+
+  run docker logs nginx-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  run echo "$IP_ADDRESS"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker exec -it nginx-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/https.cert.tmpl)"
+}
+
+@test "[start] https letsencrypt" {
+  run docker image build -t nginx-docker-proxy:latest .
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker container run -d -v /var/run/docker.sock:/var/run/docker.sock --name nginx-docker-proxy nginx-docker-proxy:latest
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker run --rm --cidfile /tmp/cid-file --platform linux/amd64 --label=nginx.domains=python.example.com '--label=nginx.port-mapping=http:80:5000 https:443:5000' --label=nginx.letsencrypt=true --label=com.dokku.app-name=python --label=com.dokku.process-type=web --name "$TEST_CONTAINER_NAME" -d dokku/python-sample /start web
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  sleep 1
+
+  run docker logs nginx-docker-proxy
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  IP_ADDRESS="$(docker container inspect --format='{{.NetworkSettings.IPAddress}}' "$TEST_CONTAINER_NAME")"
+  run echo "$IP_ADDRESS"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run docker exec -it nginx-docker-proxy cat /etc/nginx/sites-enabled/sites.conf
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_cr "$(sed "s/VAR_IP_ADDRESS/$IP_ADDRESS/" fixtures/https.letsencrypt.tmpl)"
 }
 
 assert_equal() {
   if [[ "$1" != "$2" ]]; then
     {
       echo "expected: $1"
-      echo "actual:   $2"
+      echo "actual: $2"
+      echo "diff:"
+      diff <(echo "$1") <(echo "$2")
     } | flunk
   fi
 }
@@ -114,6 +339,19 @@ assert_output() {
     expected="$1"
   fi
   assert_equal "$expected" "$output"
+}
+
+# Compares output while removing carriage returns
+# ShellCheck doesn't know about $output from Bats
+# shellcheck disable=SC2154
+assert_output_cr() {
+  local expected
+  if [[ $# -eq 0 ]]; then
+    expected="$(cat -)"
+  else
+    expected="$1"
+  fi
+  assert_equal "$expected" "$(echo "$output" | tr -d '\r')"
 }
 
 # ShellCheck doesn't know about $output from Bats


### PR DESCRIPTION
This takes advantage of lua-resty-auto-ssl to provide on-demand ssl support while also preserving the existing manual cert support.

Also add test coverage for grpc(s)/http(s) port mappings.