### PR TITLE
fix: ensure the storage directory is created with the correct perms

### DIFF
--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -12,6 +12,9 @@ main() {
     -keyout /etc/ssl/resty-auto-ssl-fallback.key \
     -out /etc/ssl/resty-auto-ssl-fallback.crt
 
+  mkdir -p /etc/resty-auto-ssl/storage
+  chown www-data:www-data /etc/resty-auto-ssl/storage
+
   echo "====> Starting server"
   exec "$@"
 }


### PR DESCRIPTION
Without this, openresty attempts to create it and fails due to the worker processes not having root perms to do so if the /etc/resty-auto-ssl directory is mounted.