### PR TITLE
fix: start docker-gen after two seconds to avoid race condition

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-docker-gen: docker-gen -config /app/config.toml
+docker-gen: docker-gen-wrapper -config /app/config.toml
 nginx: openresty -g 'daemon off;' -c /etc/nginx/nginx.conf
 logrotate: run-logrotate

--- a/bin/docker-gen-wrapper
+++ b/bin/docker-gen-wrapper
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+main() {
+  echo "====> Sleeping for two seconds to allow server time to start"
+  sleep 2
+
+  echo "====> Starting server"
+  docker-gen "$@"
+}
+
+main "$@"

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -15,7 +15,7 @@ main() {
   mkdir -p /etc/resty-auto-ssl/storage
   chown www-data:www-data /etc/resty-auto-ssl/storage
 
-  echo "====> Starting server"
+  echo "====> Starting"
   exec "$@"
 }
 


### PR DESCRIPTION
If nginx isn't fully running, a reload of the process will fail, resulting in the config not being loaded the first time.