### PR TITLE
feat: disable nginx's default server catch-all behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ An docker label to group server blocks by.
 
 Set to `true` to enable debugging comments in the generated config files.
 
+#### `NGINX_IGNORE_DEFAULT_DOMAIN`
+
+> default: `true`
+
+When `true`, all requests to a domain where there is a port listener will be ignored. Set to `false` to allow nginx to handle the default domain normally.
+
 #### `NGINX_LABEL_PREFIX`
 
 > default: `nginx.`

--- a/fixtures/grpc.tmpl
+++ b/fixtures/grpc.tmpl
@@ -1,5 +1,5 @@
 upstream python-web-5000 {
-    server VAR_IP_ADDRESS:5000; # app=python process_type=web container_port=5000 network=bridge scheme=grpc
+    server VAR_IP_ADDRESS:5000;
 }
 server {
     listen                      [::]:80 http2;
@@ -10,4 +10,17 @@ server {
     location    / {
         grpc_pass  grpc://python-web-5000;
     }
+}
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen 80 default_server;
+    return 404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    return              404;
 }

--- a/fixtures/grpcs.cert.tmpl
+++ b/fixtures/grpcs.cert.tmpl
@@ -1,5 +1,5 @@
 upstream python-web-5000 {
-    server VAR_IP_ADDRESS:5000; # app=python process_type=web container_port=5000 network=bridge scheme=grpcs
+    server VAR_IP_ADDRESS:5000;
 }
 server {
     listen                      [::]:443 ssl http2;
@@ -14,4 +14,17 @@ server {
     location    / {
         grpc_pass  grpc://python-web-5000;
     }
+}
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen 80 default_server;
+    return 404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    return              404;
 }

--- a/fixtures/grpcs.letsencrypt.tmpl
+++ b/fixtures/grpcs.letsencrypt.tmpl
@@ -1,5 +1,5 @@
 upstream python-web-5000 {
-    server VAR_IP_ADDRESS:5000; # app=python process_type=web container_port=5000 network=bridge scheme=grpcs
+    server VAR_IP_ADDRESS:5000;
 }
 server {
     listen                      [::]:443 ssl http2;
@@ -18,4 +18,17 @@ server {
     location    / {
         grpc_pass  grpc://python-web-5000;
     }
+}
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen 80 default_server;
+    return 404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    return              404;
 }

--- a/fixtures/http.tmpl
+++ b/fixtures/http.tmpl
@@ -45,3 +45,16 @@ server {
         internal;
     }
 }
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen 80 default_server;
+    return 404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    return              404;
+}

--- a/fixtures/https.cert.tmpl
+++ b/fixtures/https.cert.tmpl
@@ -61,3 +61,16 @@ server {
         internal;
     }
 }
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen 80 default_server;
+    return 404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    return              404;
+}

--- a/fixtures/https.letsencrypt-no-default.tmpl
+++ b/fixtures/https.letsencrypt-no-default.tmpl
@@ -1,0 +1,144 @@
+upstream python-web-5000 {
+    server VAR_IP_ADDRESS_1:5000;
+}
+server {
+    listen                      [::]:80;
+    listen                      80;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    location ^~ /.well-known/acme-challenge/ {
+        content_by_lua_block {
+            auto_ssl:challenge_server()
+        }
+    }
+    location / {
+        return 301 https://$host:443$request_uri;
+    }
+}
+server {
+    listen                      [::]:443 ssl http2;
+    listen                      443 ssl http2;
+    server_name                 python.example.com;
+    access_log                  /var/log/nginx/python-access.log;
+    error_log                   /var/log/nginx/python-error.log;
+    ssl_certificate_by_lua_block {
+        auto_ssl:ssl_certificate()
+    }
+    # fallback certificates
+    ssl_certificate             /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key         /etc/ssl/resty-auto-ssl-fallback.key;
+    ssl_protocols               TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers   off;
+    keepalive_timeout           70;
+    location / {
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_http_version      1.1;
+        proxy_pass              http://python-web-5000;
+        proxy_read_timeout      60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+        http2_push_preload      on;
+    }
+    error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+    location /400-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 404 /404-error.html;
+    location /404-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+    location /500-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+}
+upstream python2-web-5000 {
+    server VAR_IP_ADDRESS_2:5000;
+}
+server {
+    listen                      [::]:80;
+    listen                      80;
+    server_name                 python2.example.com _;
+    access_log                  /var/log/nginx/python2-access.log;
+    error_log                   /var/log/nginx/python2-error.log;
+    location ^~ /.well-known/acme-challenge/ {
+        content_by_lua_block {
+            auto_ssl:challenge_server()
+        }
+    }
+    location / {
+        return 301 https://$host:443$request_uri;
+    }
+}
+server {
+    listen                      [::]:443 ssl http2;
+    listen                      443 ssl http2;
+    server_name                 python2.example.com _;
+    access_log                  /var/log/nginx/python2-access.log;
+    error_log                   /var/log/nginx/python2-error.log;
+    ssl_certificate_by_lua_block {
+        auto_ssl:ssl_certificate()
+    }
+    # fallback certificates
+    ssl_certificate             /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key         /etc/ssl/resty-auto-ssl-fallback.key;
+    ssl_protocols               TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers   off;
+    keepalive_timeout           70;
+    location / {
+        gzip                    on;
+        gzip_buffers            4 32k;
+        gzip_comp_level         6;
+        gzip_min_length         1100;
+        gzip_types              text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+        gzip_vary               on;
+        proxy_buffer_size       4096;
+        proxy_buffering         on;
+        proxy_buffers           8 4096;
+        proxy_busy_buffers_size 8192;
+        proxy_http_version      1.1;
+        proxy_pass              http://python2-web-5000;
+        proxy_read_timeout      60s;
+        proxy_set_header        Connection $http_connection;
+        proxy_set_header        Host $http_host;
+        proxy_set_header        Upgrade $http_upgrade;
+        proxy_set_header        X-Forwarded-For $remote_addr;
+        proxy_set_header        X-Forwarded-Port $server_port;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Request-Start $msec;
+        http2_push_preload      on;
+    }
+    error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
+    location /400-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 404 /404-error.html;
+    location /404-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+    error_page 500 501 502 503 504 505 506 507 508 509 510 511 /500-error.html;
+    location /500-error.html {
+        root /etc/nginx/errors;
+        internal;
+    }
+}

--- a/fixtures/https.letsencrypt.tmpl
+++ b/fixtures/https.letsencrypt.tmpl
@@ -70,3 +70,16 @@ server {
         internal;
     }
 }
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen 80 default_server;
+    return 404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    return              404;
+}

--- a/templates/http.conf.tmpl
+++ b/templates/http.conf.tmpl
@@ -1,4 +1,5 @@
 {{ $upstreams := dict }}
+{{ $all_domains := dict }}
 {{ $label_prefix := default "nginx." (env "NGINX_LABEL_PREFIX") }}
 {{ $app_label := default "com.dokku.app-name" (env "NGINX_APP_LABEL") }}
 {{ $process_label := default "com.dokku.process-type" (env "NGINX_PROCESS_LABEL") }}
@@ -66,11 +67,18 @@ upstream {{ $app }}-{{ $process_type }}-{{ $container_port }} {
 {{ $nginx_access_log_format := when (contains $first_container.Labels (printf "%saccess-log-format" $label_prefix)) (index $first_container.Labels (printf "%saccess-log-format" $label_prefix)) "" }}
 {{ $nginx_error_log_path := when (contains $first_container.Labels (printf "%serror-log-path" $label_prefix)) (index $first_container.Labels (printf "%serror-log-path" $label_prefix)) (printf "/var/log/nginx/%s-error.log" $app) }}
 {{ $nginx_domains := when (contains $first_container.Labels (printf "%sdomains" $label_prefix)) (index $first_container.Labels (printf "%sdomains" $label_prefix)) "" }}
+{{ $nginx_domains_list := splitList " " $nginx_domains }}
 {{ $nginx_https_port := when (contains $first_container.Labels (printf "%shttps-port" $label_prefix)) (index $first_container.Labels (printf "%shttps-port" $label_prefix)) "443" }}
 {{ $nginx_letsencrypt := when (contains $first_container.Labels (printf "%sletsencrypt" $label_prefix)) (index $first_container.Labels (printf "%sletsencrypt" $label_prefix)) "" }}
 {{ $nginx_letsencrypt_enabled := eq $nginx_letsencrypt "true" }}
 {{ $nginx_has_cert := exists (printf "/etc/nginx/ssl/%s-server.key" $app) }}
 {{ $nginx_ssl_enabled := or ($nginx_has_cert) ($nginx_letsencrypt_enabled) }}
+
+{{ range $nginx_domains_list }}
+    {{ if ne (trim .) "" }}
+        {{ $_ := set $all_domains . . }}
+    {{ end }}
+{{ end }}
 
 {{ $port_mappings := split (trim (when (contains $first_container.Labels (printf "%sport-mapping" $label_prefix)) (index $first_container.Labels (printf "%sport-mapping" $label_prefix)) "http:80:5000")) " " }}
 {{ range $_, $port_map := $port_mappings  }}
@@ -216,4 +224,20 @@ server {
 {{ end }}
 {{ end }}
 {{ end }}
+{{ end }}
+
+{{ if and (ne (env "NGINX_IGNORE_DEFAULT_DOMAIN") "false") (not (hasKey $all_domains "_")) }}
+# set a default server block if there is no default (_) server
+server {
+    server_name _;
+    listen 80 default_server;
+    return 404;
+}
+server {
+    listen              443 ssl;
+    server_name         _;
+    ssl_certificate     /etc/ssl/resty-auto-ssl-fallback.crt;
+    ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+    return              404;
+}
 {{ end }}


### PR DESCRIPTION
By default, nginx will route any hostname that does not match a server block to the first server block (in lexicographical order) if there is one listening on the requested port. While it can be useful, this behavior isn't something that users expect, and so we implement a hack to block it for at least ports 80 and 443 if there isn't a detected catch-all domain.

Ideally we create a server block for each port being listened to and associated domains there, but this implementation is good enough for now.